### PR TITLE
Added start-in-devel-box script to package.json. (for Config #266)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start-in-devel-box": "ng serve --host=0.0.0.0 --port=80",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
The script starts a server to listen on 0.0.0.0:80 (as opposed to
localhost:4200 in case of the the start script).